### PR TITLE
Create JPA repository and add tests for Beer entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ target/
 *.iws
 *.iml
 *.ipr
+.DS_Store
 
 ### NetBeans ###
 /nbproject/private/

--- a/src/main/java/tom/springframework/vibecodingmvc/entities/Beer.java
+++ b/src/main/java/tom/springframework/vibecodingmvc/entities/Beer.java
@@ -1,0 +1,48 @@
+package tom.springframework.vibecodingmvc.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Version;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Beer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Version
+    private Integer version;
+
+    private String beerName;
+    private String beerStyle;
+    private String upc;
+    private Integer quantityOnHand;
+    private BigDecimal price;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+    
+    @UpdateTimestamp
+    private LocalDateTime updatedDate;
+
+}

--- a/src/main/java/tom/springframework/vibecodingmvc/repositories/BeerRepository.java
+++ b/src/main/java/tom/springframework/vibecodingmvc/repositories/BeerRepository.java
@@ -1,0 +1,8 @@
+package tom.springframework.vibecodingmvc.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import tom.springframework.vibecodingmvc.entities.Beer;
+
+public interface BeerRepository extends JpaRepository<Beer, Integer> {
+    // Spring Data JPA will automatically implement basic CRUD operations
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=vibecodingmvc
+
+# application-test.properties
+#spring.jpa.hibernate.ddl-auto=create #none for production

--- a/src/test/java/tom/springframework/vibecodingmvc/repositories/BeerRepositoryTest.java
+++ b/src/test/java/tom/springframework/vibecodingmvc/repositories/BeerRepositoryTest.java
@@ -1,0 +1,126 @@
+package tom.springframework.vibecodingmvc.repositories;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import tom.springframework.vibecodingmvc.entities.Beer;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class BeerRepositoryTest {
+
+    @Autowired
+    BeerRepository beerRepository;
+
+    @Test
+    void testSaveBeer() {
+        // Given
+        Beer beer = Beer.builder()
+                .beerName("Test Beer")
+                .beerStyle("IPA")
+                .upc("123456")
+                .price(new BigDecimal("12.99"))
+                .quantityOnHand(100)
+                .build();
+
+        // When
+        Beer savedBeer = beerRepository.save(beer);
+
+        // Then
+        assertThat(savedBeer).isNotNull();
+        assertThat(savedBeer.getId()).isNotNull();
+    }
+
+    @Test
+    void testGetBeerById() {
+        // Given
+        Beer beer = Beer.builder()
+                .beerName("Test Beer")
+                .beerStyle("IPA")
+                .upc("123456")
+                .price(new BigDecimal("12.99"))
+                .quantityOnHand(100)
+                .build();
+        Beer savedBeer = beerRepository.save(beer);
+
+        // When
+        Optional<Beer> fetchedBeerOptional = beerRepository.findById(savedBeer.getId());
+
+        // Then
+        assertThat(fetchedBeerOptional).isPresent();
+        Beer fetchedBeer = fetchedBeerOptional.get();
+        assertThat(fetchedBeer.getBeerName()).isEqualTo("Test Beer");
+    }
+
+    @Test
+    void testUpdateBeer() {
+        // Given
+        Beer beer = Beer.builder()
+                .beerName("Original Name")
+                .beerStyle("IPA")
+                .upc("123456")
+                .price(new BigDecimal("12.99"))
+                .quantityOnHand(100)
+                .build();
+        Beer savedBeer = beerRepository.save(beer);
+
+        // When
+        savedBeer.setBeerName("Updated Name");
+        Beer updatedBeer = beerRepository.save(savedBeer);
+
+        // Then
+        assertThat(updatedBeer.getBeerName()).isEqualTo("Updated Name");
+    }
+
+    @Test
+    void testDeleteBeer() {
+        // Given
+        Beer beer = Beer.builder()
+                .beerName("Delete Me")
+                .beerStyle("Lager")
+                .upc("654321")
+                .price(new BigDecimal("9.99"))
+                .quantityOnHand(50)
+                .build();
+        Beer savedBeer = beerRepository.save(beer);
+
+        // When
+        beerRepository.deleteById(savedBeer.getId());
+        Optional<Beer> deletedBeerOptional = beerRepository.findById(savedBeer.getId());
+
+        // Then
+        assertThat(deletedBeerOptional).isEmpty();
+    }
+
+    @Test
+    void testListBeers() {
+        // Given
+        beerRepository.deleteAll(); // Clear any existing data
+        Beer beer1 = Beer.builder()
+                .beerName("Beer 1")
+                .beerStyle("IPA")
+                .upc("111111")
+                .price(new BigDecimal("11.99"))
+                .quantityOnHand(100)
+                .build();
+        Beer beer2 = Beer.builder()
+                .beerName("Beer 2")
+                .beerStyle("Stout")
+                .upc("222222")
+                .price(new BigDecimal("13.99"))
+                .quantityOnHand(200)
+                .build();
+        beerRepository.saveAll(List.of(beer1, beer2));
+
+        // When
+        List<Beer> beers = beerRepository.findAll();
+
+        // Then
+        assertThat(beers).hasSize(2);
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,14 @@
+# H2 Database Configuration for Tests
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+# Hibernate Configuration
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# H2 Console (optional, for debugging)
+spring.h2.console.enabled=true


### PR DESCRIPTION
- Created `BeerRepository` interface extending JpaRepository to manage Beer entities.
- Added `BeerRepositoryTest` class to test basic CRUD operations using Spring Boot and H2 in-memory DB.
- Verified that all tests pass successfully.
- Updated `application.properties` for test-specific settings.

This PR supports persistence layer development and test validation for the Beer domain model.