### PR TITLE
Document OpenAPI file structure and update related prompts

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -258,3 +258,40 @@ spring.flyway.locations=classpath:db/migration
 # Prefer schema managed by migrations; validate entity DDL against schema
 spring.jpa.hibernate.ddl-auto=validate
 ```
+
+## OpenAPI documentation (Redocly)
+
+Location
+- Root spec: openapi-starter-main/openapi/openapi.yaml
+- Split files are referenced via $ref to keep the spec modular and readable.
+
+Path files and naming
+- Each path item can be moved to its own file under openapi-starter-main/openapi/paths and referenced from openapi.yaml with:
+  
+  Example mappings from this repo:
+  - '/users/{username}' -> paths/users_{username}.yaml
+  - '/user' -> paths/user.yaml
+  - '/user/list' -> paths/user-status.yaml
+  - '/echo' -> paths/echo.yaml
+- Convention: prefer mirroring the URL by replacing '/' with '_' and keeping path parameters in curly braces, e.g. '/orders/{id}' -> paths/orders_{id}.yaml.
+- Descriptive alternatives are allowed (like user-status.yaml) as long as the openapi.yaml $ref points to the correct file.
+
+Components and references
+- Common parts live under openapi-starter-main/openapi/components:
+  - Schemas: components/schemas/*.yaml (e.g., User.yaml, Email.yaml, Problem.yaml)
+  - Responses: components/responses/*.yaml (e.g., Problem.yaml referencing schemas/Problem.yaml)
+  - Headers: components/headers/*.yaml (e.g., ExpiresAfter.yaml)
+  - Security schemes are defined inline under components.securitySchemes in openapi.yaml.
+- Use relative $ref paths from the referencing file, for example:
+  - From a path file: $ref: '../components/schemas/User.yaml'
+  - From the root openapi.yaml: $ref: 'components/schemas/User.yaml'
+
+Previewing docs
+- A simple static docs page exists at openapi-starter-main/docs/index.html (uses the bundled spec or points to the live one).
+- You can also use Redocly preview in the OpenAPI project directory: npm start
+
+Validate/test the OpenAPI definition
+- Prerequisite: Node.js installed. In openapi-starter-main run once: npm install
+- Lint/validate: npm test
+  - This runs redocly lint using the script defined in openapi-starter-main/package.json.
+- Optional: bundle the spec for distribution: npm run build (outputs dist/bundle.yaml)

--- a/prompts/Other/prompts.md
+++ b/prompts/Other/prompts.md
@@ -1,0 +1,18 @@
+
+
+
+Inspect .junie/guidelines.md. Add a brief section about flyway migrations with Spring Boot. Include information about the default directory and version naming.
+
+----------------
+
+Branch 16:
+
+Create flyway migration scripts for the JPA entities in this project. Use one script starting with the lowest version number. Inspect and update the application.properties to enable flyway migrations with Spring Boot.
+
+---------------
+Branch 17:
+
+Inspect OpenAPI specification in openapi-starter-main/openapi/openapi.yaml. This is the API documentation for this project. Observe how file references are used. Note how the file names from path operations are determined from the path of the API, and how components such as headers and schemas are defined in file references. Update the file .junie/guidelines.md with a description of the API documentation, file naming conventions, and how components are defined. Provide instructions about testing the OpenAPI Specification using the command npm test. 
+
+-------------
+

--- a/prompts/create-beer-order/prompts.md
+++ b/prompts/create-beer-order/prompts.md
@@ -21,12 +21,3 @@ Write the task list to `prompts/create-beer-order/tasks.md` file.
 Complete the task list `prompts/create-beer-order/tasks.md`. Inspect the requirements.md and plan.md and task.md (task list). 
 Implement the tasks in the task list. Focus on completing the tasks in order. Mark the task complete as it is done 
 using [x]. As each step is completed, it is very important to update the task list mark and the task as done [x]. 
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-Inspect .junie/guidelines.md. Add a brief section about flyway migrations with Spring Boot. Include information about the default directory and version naming. 
-
-----------------
-----------------
-
-Create flyway migration scripts for the JPA entities in this project. Use one script starting with the lowest version number. Inspect and update the application.properties to enable flyway migrations with Spring Boot. 


### PR DESCRIPTION
- Add OpenAPI documentation guidelines including file naming conventions, component definitions, and testing instructions to `.junie/guidelines.md`.
- Update prompts to include tasks for enhancing Flyway and OpenAPI documentation.
- Introduce new OpenAPI-related guidance in `prompts/Other/prompts.md`.