### PR TITLE
Add OpenAPI documentation to BeerOrderController and related DTOs

### DIFF
--- a/prompts/Other/prompts.md
+++ b/prompts/Other/prompts.md
@@ -62,3 +62,7 @@ E) When finished:
 	•	Report which files were updated.
 </issue_description>
 If you need to know the date and time for this issue, the current local date and time is: 2025-09-01 17:46.
+
+-----------------------------
+Inspect /prompts/Other/document-beerOrder-APIs.md file and use the instructions in it to build Beer Order documentation using
+Springdoc annotations.

--- a/src/main/java/tom/springframework/vibecodingmvc/models/BeerOrderLineResponse.java
+++ b/src/main/java/tom/springframework/vibecodingmvc/models/BeerOrderLineResponse.java
@@ -1,10 +1,26 @@
 package tom.springframework.vibecodingmvc.models;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Beer order line details")
 public record BeerOrderLineResponse(
+        @Schema(description = "Line identifier", example = "10")
         Integer id,
+
+        @Schema(description = "Beer identifier", example = "1")
         Integer beerId,
+
+        @Schema(description = "Name of the beer", example = "Galaxy Cat IPA")
         String beerName,
+
+        @Schema(description = "Quantity ordered", minimum = "1", example = "2")
         Integer orderQuantity,
+
+        @Schema(description = "Quantity allocated", minimum = "0", example = "0")
         Integer quantityAllocated,
+
+        @Schema(description = "Line status",
+                allowableValues = {"PENDING","ALLOCATED","BACKORDERED","SHIPPED"},
+                example = "PENDING")
         String status
 ) {}

--- a/src/main/java/tom/springframework/vibecodingmvc/models/BeerOrderResponse.java
+++ b/src/main/java/tom/springframework/vibecodingmvc/models/BeerOrderResponse.java
@@ -4,12 +4,34 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Beer order details")
 public record BeerOrderResponse(
+        @Schema(description = "Order identifier", example = "42")
         Integer id,
+
+        @Schema(description = "Client-provided reference for the order", example = "PO-2025-0001")
         String customerRef,
+
+        @Schema(description = "Payment amount", example = "24.99")
         BigDecimal paymentAmount,
+
+        @Schema(description = "Current status of the order",
+                allowableValues = {"PENDING","PAID","CANCELLED"},
+                example = "PENDING")
         String status,
+
+        @ArraySchema(
+                schema = @Schema(implementation = BeerOrderLineResponse.class),
+                arraySchema = @Schema(example = "[{\"id\":10,\"beerId\":1,\"beerName\":\"Galaxy Cat IPA\",\"orderQuantity\":2,\"quantityAllocated\":0,\"status\":\"PENDING\"}]")
+        )
         List<BeerOrderLineResponse> lines,
+
+        @Schema(type = "string", format = "date-time", example = "2025-08-20T14:13:00Z")
         LocalDateTime createdDate,
+
+        @Schema(type = "string", format = "date-time", example = "2025-08-20T14:13:00Z")
         LocalDateTime updatedDate
 ) {}

--- a/src/main/java/tom/springframework/vibecodingmvc/models/CreateBeerOrderCommand.java
+++ b/src/main/java/tom/springframework/vibecodingmvc/models/CreateBeerOrderCommand.java
@@ -2,15 +2,33 @@ package tom.springframework.vibecodingmvc.models;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Command to create a beer order")
 public record CreateBeerOrderCommand(
+        @Schema(description = "Client-provided reference for the order",
+                example = "PO-2025-0001")
         String customerRef,
+
+        @Schema(description = "Payment amount for the order",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                minimum = "0",
+                example = "24.99")
         @NotNull @PositiveOrZero BigDecimal paymentAmount,
+
+        @ArraySchema(
+                minItems = 1,
+                schema = @Schema(implementation = CreateBeerOrderItem.class),
+                arraySchema = @Schema(example = "[{\"beerId\":1,\"quantity\":2}]")
+        )
+        @Schema(description = "Order items",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull @Size(min = 1) List<@Valid CreateBeerOrderItem> items
 ) {}

--- a/src/main/java/tom/springframework/vibecodingmvc/models/CreateBeerOrderItem.java
+++ b/src/main/java/tom/springframework/vibecodingmvc/models/CreateBeerOrderItem.java
@@ -3,7 +3,17 @@ package tom.springframework.vibecodingmvc.models;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "A single line item in a beer order")
 public record CreateBeerOrderItem(
+        @Schema(description = "Identifier of the beer to order",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                example = "1")
         @NotNull Integer beerId,
+
+        @Schema(description = "Quantity of the beer to order",
+                minimum = "1",
+                example = "2")
         @Positive int quantity
 ) {}


### PR DESCRIPTION
- Annotate BeerOrderController with @Tag, @Operation, @ApiResponses, @Parameter for API documentation.
- Add @Schema annotations with descriptions, examples, and validation constraints to CreateBeerOrderCommand, CreateBeerOrderItem, BeerOrderResponse, and BeerOrderLineResponse.
- Include response examples and OpenAPI integration in Beer Order endpoints.
- Update prompts/Other/prompts.md with instructions for Beer Order API documentation.